### PR TITLE
Fixed deprecation of ${var}

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,7 +71,7 @@ class ServiceProvider extends LaravelServiceProvider
                     foreach ($hierarchyKeys as $key) {
                         $value = data_get($item, $key);
                         if (!isset($value)) {
-                            throw new \RuntimeException("Grouping error: '${key}' doesn't exist in collection");
+                            throw new \RuntimeException("Grouping error: '{$key}' doesn't exist in collection");
                         }
 
                         if (!isset($hierarchyItemPointer[$value])) {


### PR DESCRIPTION
STDERR:
         PHP Deprecated:  Using ${var} in strings is deprecated, use {$var}
         instead in
         /src/repo/laravel/vendor/softonic/laravel-collection-extended/src/Servi
         ceProvider.php on line 74